### PR TITLE
Avoid using specialization for capturing

### DIFF
--- a/ct/src/capture.rs
+++ b/ct/src/capture.rs
@@ -36,7 +36,7 @@ fn expand(key_value: FieldValue, fn_name: Ident) -> TokenStream {
         {
             extern crate emit;
             use emit::rt::__private::__PrivateCapture;
-            (#key_expr, (#expr).#fn_name())
+            (#key_expr, (&#expr).#fn_name())
         }
     )
 }

--- a/ct/src/lib.rs
+++ b/ct/src/lib.rs
@@ -9,6 +9,9 @@ extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 
+#[macro_use]
+extern crate syn;
+
 use proc_macro2::TokenStream;
 
 mod capture;
@@ -72,14 +75,21 @@ Capture a key-value pair using its `Debug` implementation.
 */
 #[proc_macro_attribute]
 pub fn as_debug(
-    _: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(capture::rename_capture_tokens(
         capture::RenameCaptureTokens {
+            args: TokenStream::from(args),
             expr: TokenStream::from(item),
             predicate: |ident| ident.starts_with("__private_capture"),
-            to: quote!(__private_capture_as_debug),
+            to: |args| {
+                if args.capture {
+                    quote!(__private_capture_as_debug)
+                } else {
+                    quote!(__private_capture_anon_as_debug)
+                }
+            },
         },
     ))
 }
@@ -89,14 +99,21 @@ Capture a key-value pair using its `Display` implementation.
 */
 #[proc_macro_attribute]
 pub fn as_display(
-    _: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(capture::rename_capture_tokens(
         capture::RenameCaptureTokens {
+            args: TokenStream::from(args),
             expr: TokenStream::from(item),
             predicate: |ident| ident.starts_with("__private_capture"),
-            to: quote!(__private_capture_as_display),
+            to: |args| {
+                if args.capture {
+                    quote!(__private_capture_as_display)
+                } else {
+                    quote!(__private_capture_anon_as_display)
+                }
+            },
         },
     ))
 }
@@ -106,14 +123,21 @@ Capture a key-value pair using its `sval::Value` implementation.
 */
 #[proc_macro_attribute]
 pub fn as_sval(
-    _: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(capture::rename_capture_tokens(
         capture::RenameCaptureTokens {
+            args: TokenStream::from(args),
             expr: TokenStream::from(item),
             predicate: |ident| ident.starts_with("__private_capture"),
-            to: quote!(__private_capture_as_sval),
+            to: |args| {
+                if args.capture {
+                    quote!(__private_capture_as_sval)
+                } else {
+                    quote!(__private_capture_anon_as_sval)
+                }
+            },
         },
     ))
 }
@@ -123,14 +147,21 @@ Capture a key-value pair using its `serde::Serialize` implementation.
 */
 #[proc_macro_attribute]
 pub fn as_serde(
-    _: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(capture::rename_capture_tokens(
         capture::RenameCaptureTokens {
+            args: TokenStream::from(args),
             expr: TokenStream::from(item),
             predicate: |ident| ident.starts_with("__private_capture"),
-            to: quote!(__private_capture_as_serde),
+            to: |args| {
+                if args.capture {
+                    quote!(__private_capture_as_serde)
+                } else {
+                    quote!(__private_capture_anon_as_serde)
+                }
+            },
         },
     ))
 }
@@ -143,14 +174,15 @@ It must use `source` as the key name.
 */
 #[proc_macro_attribute]
 pub fn source(
-    _: proc_macro::TokenStream,
+    args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(capture::rename_capture_tokens(
         capture::RenameCaptureTokens {
+            args: TokenStream::from(args),
             expr: TokenStream::from(item),
             predicate: |ident| ident.starts_with("__private_capture"),
-            to: quote!(__private_capture_as_error),
+            to: |_| quote!(__private_capture_as_error),
         },
     ))
 }
@@ -183,6 +215,15 @@ pub fn __private_capture_as_display(item: proc_macro::TokenStream) -> proc_macro
     proc_macro::TokenStream::from(capture::expand_tokens(capture::ExpandTokens {
         expr: TokenStream::from(item),
         fn_name: |_| quote!(__private_capture_as_display),
+    }))
+}
+
+#[proc_macro]
+#[doc(hidden)]
+pub fn __private_capture_anon_as_display(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    proc_macro::TokenStream::from(capture::expand_tokens(capture::ExpandTokens {
+        expr: TokenStream::from(item),
+        fn_name: |_| quote!(__private_capture_anon_as_display),
     }))
 }
 

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -10,7 +10,8 @@ std = ["value-bag/std", "value-bag/error", "sval/std"]
 serde = ["serde_lib", "value-bag/serde"]
 
 [dependencies.value-bag]
-path = "../../value-bag"
+git = "https://github.com/sval-rs/value-bag"
+branch = "feat/str-capturing"
 features = ["sval"]
 
 [dependencies.fv-template]

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -10,7 +10,7 @@ std = ["value-bag/std", "value-bag/error", "sval/std"]
 serde = ["serde_lib", "value-bag/serde"]
 
 [dependencies.value-bag]
-version = "1.0.0-alpha.7"
+path = "../../value-bag"
 features = ["sval"]
 
 [dependencies.fv-template]

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -10,8 +10,7 @@ std = ["value-bag/std", "value-bag/error", "sval/std"]
 serde = ["serde_lib", "value-bag/serde"]
 
 [dependencies.value-bag]
-git = "https://github.com/sval-rs/value-bag"
-branch = "feat/str-capturing"
+version = "1.0.0-alpha.8"
 features = ["sval"]
 
 [dependencies.fv-template]

--- a/rt/src/capture.rs
+++ b/rt/src/capture.rs
@@ -217,7 +217,6 @@ mod tests {
     }
 
     #[test]
-
     fn capture_sval() {
         use sval::value::{self, Value};
 

--- a/rt/src/capture.rs
+++ b/rt/src/capture.rs
@@ -34,7 +34,7 @@ where
     T: fmt::Display + ?Sized + 'static,
 {
     fn capture(&self) -> ValueBag {
-        ValueBag::capture_dyn_display(self)
+        ValueBag::try_capture(*self).unwrap_or_else(|| ValueBag::from_display(self))
     }
 }
 
@@ -43,7 +43,7 @@ where
     T: fmt::Debug + ?Sized + 'static,
 {
     fn capture(&self) -> ValueBag {
-        ValueBag::capture_dyn_debug(self)
+        ValueBag::try_capture(*self).unwrap_or_else(|| ValueBag::from_debug(self))
     }
 }
 
@@ -52,7 +52,7 @@ where
     T: Value + ?Sized + 'static,
 {
     fn capture(&self) -> ValueBag {
-        ValueBag::capture_dyn_sval1(self)
+        ValueBag::try_capture(*self).unwrap_or_else(|| ValueBag::from_sval1(self))
     }
 }
 
@@ -62,7 +62,7 @@ where
     T: Serialize + 'static,
 {
     fn capture(&self) -> ValueBag {
-        ValueBag::capture_serde1(*self)
+        ValueBag::try_capture(self).unwrap_or_else(|| ValueBag::from_serde1(self))
     }
 }
 

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -4,8 +4,6 @@ Implementation details for `emit!` macros.
 This crate is not intended to be consumed directly.
 */
 
-#![feature(min_specialization)] // required to accept `T: Sized + 'static || dyn Trait || str`
-#![feature(extern_types)] // could be replaced by empty enums
 #![no_std]
 
 #[cfg(any(feature = "std", test))]

--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -4,6 +4,8 @@ Implementation details for `emit!` macros.
 This crate is not intended to be consumed directly.
 */
 
+#![feature(min_specialization)] // required to accept `T: Sized + 'static || dyn Trait || str`
+#![feature(extern_types)] // could be replaced by empty enums
 #![no_std]
 
 #[cfg(any(feature = "std", test))]

--- a/tests/ui/fail/log_cfg_unused.rs
+++ b/tests/ui/fail/log_cfg_unused.rs
@@ -1,18 +1,15 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 #![deny(unused_variables)]
 
-#[macro_use]
-extern crate emit;
-
 fn main() {
     let a = String::from("hello");
 
     // Unused by the log statement
     let c = 42;
 
-    info!("A log with cfgs {#[cfg(disabled)] b: 17}",
+    emit::info!("A log with cfgs {#[cfg(disabled)] b: 17}",
         a,
-        #[as_debug]
+        #[emit::as_debug]
         #[cfg(disabled)]
         c,
         d: String::from("short lived!"),

--- a/tests/ui/fail/log_cfg_unused.stderr
+++ b/tests/ui/fail/log_cfg_unused.stderr
@@ -1,11 +1,11 @@
 error: unused variable: `c`
-  --> $DIR/log_cfg_unused.rs:11:9
-   |
-11 |     let c = 42;
-   |         ^ help: if this is intentional, prefix it with an underscore: `_c`
-   |
+ --> $DIR/log_cfg_unused.rs:8:9
+  |
+8 |     let c = 42;
+  |         ^ help: if this is intentional, prefix it with an underscore: `_c`
+  |
 note: the lint level is defined here
-  --> $DIR/log_cfg_unused.rs:2:9
-   |
-2  | #![deny(unused_variables)]
-   |         ^^^^^^^^^^^^^^^^
+ --> $DIR/log_cfg_unused.rs:2:9
+  |
+2 | #![deny(unused_variables)]
+  |         ^^^^^^^^^^^^^^^^

--- a/tests/ui/fail/log_interpolated_unsatisfied_trait_debug.rs
+++ b/tests/ui/fail/log_interpolated_unsatisfied_trait_debug.rs
@@ -1,11 +1,8 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
-#[macro_use]
-extern crate emit;
-
 // Does not implement `Display`
 struct Input;
 
 fn main() {
-    info!("Text \"and\" {#[as_debug] a: Input} and more");
+    emit::info!("Text \"and\" {#[emit::as_debug] a: Input} and more");
 }

--- a/tests/ui/fail/log_interpolated_unsatisfied_trait_debug.stderr
+++ b/tests/ui/fail/log_interpolated_unsatisfied_trait_debug.stderr
@@ -1,10 +1,10 @@
 error[E0277]: `Input` doesn't implement `Debug`
-  --> $DIR/log_interpolated_unsatisfied_trait_debug.rs:10:26
-   |
-10 |     info!("Text \"and\" {#[as_debug] a: Input} and more");
-   |                          ^^^^^^^^^^^^^^^^^^^^ `Input` cannot be formatted using `{:?}`
-   |
-   = help: the trait `Debug` is not implemented for `Input`
-   = note: add `#[derive(Debug)]` or manually implement `Debug`
-   = note: required because of the requirements on the impl of `emit::emit_rt::capture::Capture<emit::emit_rt::capture::CaptureDebug>` for `Input`
-   = note: this error originates in the macro `emit::ct::__private_capture_as_debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $DIR/log_interpolated_unsatisfied_trait_debug.rs:7:32
+  |
+7 |     emit::info!("Text \"and\" {#[emit::as_debug] a: Input} and more");
+  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ `Input` cannot be formatted using `{:?}`
+  |
+  = help: the trait `Debug` is not implemented for `Input`
+  = note: add `#[derive(Debug)]` to `Input` or manually `impl Debug for Input`
+  = note: required because of the requirements on the impl of `main::emit::emit_rt::capture::Capture<main::emit::emit_rt::capture::CaptureDebug>` for `&Input`
+  = note: this error originates in the macro `emit::ct::__private_capture_as_debug` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/fail/log_interpolated_unsatisfied_trait_default.rs
+++ b/tests/ui/fail/log_interpolated_unsatisfied_trait_default.rs
@@ -1,11 +1,8 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
-#[macro_use]
-extern crate emit;
-
 // Does not implement `Display`
 struct Input;
 
 fn main() {
-    info!("Text \"and\" {a: Input} and more");
+    emit::info!("Text \"and\" {a: Input} and more");
 }

--- a/tests/ui/fail/log_interpolated_unsatisfied_trait_default.stderr
+++ b/tests/ui/fail/log_interpolated_unsatisfied_trait_default.stderr
@@ -1,10 +1,10 @@
 error[E0277]: `Input` doesn't implement `std::fmt::Display`
-  --> $DIR/log_interpolated_unsatisfied_trait_default.rs:10:26
-   |
-10 |     info!("Text \"and\" {a: Input} and more");
-   |                          ^^^^^^^^ `Input` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `Input`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: required because of the requirements on the impl of `emit::emit_rt::capture::Capture<emit::emit_rt::capture::CaptureDisplay>` for `Input`
-   = note: this error originates in the macro `emit::ct::__private_capture` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $DIR/log_interpolated_unsatisfied_trait_default.rs:7:32
+  |
+7 |     emit::info!("Text \"and\" {a: Input} and more");
+  |                                ^^^^^^^^ `Input` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `Input`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required because of the requirements on the impl of `main::emit::emit_rt::capture::Capture<main::emit::emit_rt::capture::CaptureDisplay>` for `&Input`
+  = note: this error originates in the macro `emit::ct::__private_capture` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/fail/log_many_refs.rs
+++ b/tests/ui/fail/log_many_refs.rs
@@ -1,0 +1,9 @@
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
+
+fn main() {
+    tracing_subscriber::fmt().init();
+
+    fn call(v: &&&str) {
+        emit::info!("Logging with a deeply nested {value: v}");
+    }
+}

--- a/tests/ui/fail/log_many_refs.stderr
+++ b/tests/ui/fail/log_many_refs.stderr
@@ -1,0 +1,7 @@
+error[E0621]: explicit lifetime required in the type of `v`
+ --> $DIR/log_many_refs.rs:7:52
+  |
+7 |         emit::info!("Logging with a deeply nested {value: v}");
+  |                                                    ^^^^^^^^ lifetime `'static` required
+  |
+  = note: this error originates in the macro `emit::ct::__private_capture` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/fail/log_misplaced_attr.rs
+++ b/tests/ui/fail/log_misplaced_attr.rs
@@ -1,0 +1,9 @@
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
+
+fn main() {
+    tracing_subscriber::fmt().init();
+
+    let a = String::from("hello");
+
+    emit::info!("Some text", value: #[emit::as_display] a);
+}

--- a/tests/ui/fail/log_misplaced_attr.stderr
+++ b/tests/ui/fail/log_misplaced_attr.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> $DIR/log_misplaced_attr.rs:8:37
+  |
+8 |     emit::info!("Some text", value: #[emit::as_display] a);
+  |                                     ^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: the emit attribute macros can only be placed on the outside of a field-value expression

--- a/tests/ui/pass/log_additional.rs
+++ b/tests/ui/pass/log_additional.rs
@@ -1,8 +1,5 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
-#[macro_use]
-extern crate emit;
-
 fn main() {
     tracing_subscriber::fmt().init();
 
@@ -16,14 +13,14 @@ fn main() {
         map
     };
 
-    info!("There's no replacements here",
+    emit::info!("There's no replacements here",
         a,
         b: 17,
-        #[as_debug]
+        #[emit::as_debug]
         c,
         d: String::from("short lived!"),
         err: e,
-        #[as_sval]
+        #[emit::as_sval]
         f,
     );
 }

--- a/tests/ui/pass/log_cfg.rs
+++ b/tests/ui/pass/log_cfg.rs
@@ -1,18 +1,15 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 #![allow(unused_variables)]
 
-#[macro_use]
-extern crate emit;
-
 fn main() {
     tracing_subscriber::fmt().init();
 
     let a = String::from("hello");
     let c = 42;
 
-    info!("A log with cfgs {#[cfg(disabled)] b: 17}",
+    emit::info!("A log with cfgs {#[cfg(disabled)] b: 17}",
         a,
-        #[as_debug]
+        #[emit::as_debug]
         #[cfg(disabled)]
         c,
         d: String::from("short lived!"),

--- a/tests/ui/pass/log_external.rs
+++ b/tests/ui/pass/log_external.rs
@@ -1,0 +1,20 @@
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
+
+extern crate emit;
+
+use uuid::Uuid;
+
+fn main() {
+    emit::target(|record| {
+        // Just make sure we can fetch a `Uuid`
+        let id = record.get("id").expect("missing id");
+        let id = id.downcast_ref::<Uuid>().expect("not a uuid");
+
+        println!("{}", id);
+        println!("{}", sval_json::to_string(record).expect("failed to serialize"));
+    });
+
+    let id = Uuid::new_v4();
+
+    emit::info!("something went wrong ({id})");
+}

--- a/tests/ui/pass/log_interpolated.rs
+++ b/tests/ui/pass/log_interpolated.rs
@@ -1,8 +1,5 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
-#[macro_use]
-extern crate emit;
-
 fn main() {
     tracing_subscriber::fmt().init();
 
@@ -16,5 +13,5 @@ fn main() {
         map
     };
 
-    info!("Text and {a} and {b: 17} and {#[as_debug] c} or {#[as_display] d: String::from(\"short lived!\")} and {err: e} and {#[as_sval] f}");
+    emit::info!("Text and {a} and {b: 17} and {#[emit::as_debug] c} or {#[emit::as_display] d: String::from(\"short lived!\")} and {err: e} and {#[emit::as_sval] f}");
 }

--- a/tests/ui/pass/log_many_ref.rs
+++ b/tests/ui/pass/log_many_ref.rs
@@ -1,0 +1,12 @@
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
+
+#[macro_use]
+extern crate emit;
+
+fn main() {
+    tracing_subscriber::fmt().init();
+
+    fn call(v: &&&str) {
+        info!("Logging with a deeply nested {value: *v}");
+    }
+}

--- a/tests/ui/pass/log_many_ref.rs
+++ b/tests/ui/pass/log_many_ref.rs
@@ -1,12 +1,10 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
-#[macro_use]
-extern crate emit;
-
 fn main() {
     tracing_subscriber::fmt().init();
 
     fn call(v: &&&str) {
-        info!("Logging with a deeply nested {value: *v}");
+        emit::info!("Logging with a deeply nested {value: ***v}");
+        emit::info!("Logging with a deeply nested {#[emit::as_display(capture: false)] value: v}");
     }
 }

--- a/tests/ui/pass/log_mixed.rs
+++ b/tests/ui/pass/log_mixed.rs
@@ -1,8 +1,5 @@
 #![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
-#[macro_use]
-extern crate emit;
-
 fn main() {
     tracing_subscriber::fmt().init();
 
@@ -16,12 +13,12 @@ fn main() {
         map
     };
 
-    info!("Text and {a} and {b} and {#[as_debug] c} or {d}",
+    emit::info!("Text and {a} and {b} and {#[emit::as_debug] c} or {d}",
         b: 17,
-        #[as_debug]
+        #[emit::as_debug]
         d: String::from("short lived!"),
         err,
-        #[as_sval]
+        #[emit::as_sval]
         f,
     );
 }


### PR DESCRIPTION
Reworks value capturing to avoid needing to depend on specialization. That's the biggest hurdle to getting this crate working on `stable`.

Depends on:

- https://github.com/sval-rs/value-bag/pull/28
- https://github.com/sval-rs/sval/pull/112